### PR TITLE
:ox: Updating to current version of oxmysql (2.6.0)

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -33,7 +33,7 @@ RegisterNetEvent('hospital:server:RespawnAtHospital', function(closestBed)
 		TriggerClientEvent('hospital:client:SetBed', -1, closestBed, true)
 		if Config.WipeInventoryOnRespawn then
 			Player.Functions.ClearInventory()
-			MySQL.Async.execute('UPDATE players SET inventory = ? WHERE citizenid = ?', { json.encode({}), Player.PlayerData.citizenid })
+			MySQL.query('UPDATE players SET inventory = ? WHERE citizenid = ?', { json.encode({}), Player.PlayerData.citizenid })
 			TriggerClientEvent('QBCore:Notify', src, 9, Lang:t('error.possessions_taken'), 5000, 0, 'mp_lobby_textures', 'cross', 'COLOR_WHITE')
 		end
 		Player.Functions.RemoveMoney("bank", Config.BillCost, "respawned-at-hospital")
@@ -45,7 +45,7 @@ RegisterNetEvent('hospital:server:RespawnAtHospital', function(closestBed)
 		TriggerClientEvent('hospital:client:SetBed', -1, 1, true)
 		if Config.WipeInventoryOnRespawn then
 			Player.Functions.ClearInventory()
-			MySQL.Async.execute('UPDATE players SET inventory = ? WHERE citizenid = ?', { json.encode({}), Player.PlayerData.citizenid })
+			MySQL.query('UPDATE players SET inventory = ? WHERE citizenid = ?', { json.encode({}), Player.PlayerData.citizenid })
 			TriggerClientEvent('QBCore:Notify', src, 9, Lang:t('error.possessions_taken'), 5000, 0, 'mp_lobby_textures', 'cross', 'COLOR_WHITE')
 		end
 		Player.Functions.RemoveMoney("bank", Config.BillCost, "respawned-at-hospital")


### PR DESCRIPTION
Requires: oxmysql update 2.6.0
----------------------------------------------------------------------------------------------------------------------------------------------------------------
Issue: Current mysql calls are outdated. 

Fix: Update the oxmysql calls to current.

Expected result: We can now to update to the newest version of oxmysql and have the resource interact without errors. Saving and loading should work as normal. 